### PR TITLE
Fix r48

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "license": "ISC",
   "devDependencies": {
     "@qualweb/dom": "^0.2.6",
-    "@qualweb/qw-page": "^0.2.12",
-    "@qualweb/types": "^0.7.2",
+    "@qualweb/qw-page": "^0.2.13",
+    "@qualweb/types": "^0.7.21",
     "@tsconfig/recommended": "^1.0.1",
     "@types/node": "^15.6.1",
     "@types/string-pixel-width": "^1.7.1",

--- a/src/accessibilityUtils/getImplicitRole.ts
+++ b/src/accessibilityUtils/getImplicitRole.ts
@@ -111,8 +111,11 @@ function getRoleOption(element: typeof window.qwElement, roleValue) {
 
 function getRoleImg(element: typeof window.qwElement, roleValue) {
   const alt = element.getElementAttribute('alt');
+  const ariaLabelledBy = element.getElementAttribute('aria-labelledby');
+  const id = element.getElementAttribute('id');
+
   let role;
-  if (alt !== '') {
+  if (alt !== '' || (ariaLabelledBy !== null && verifyAriaLabel(ariaLabelledBy, id))) {
     role = roleValue['role'];
   } else if (
     element.elementHasAttribute('alt') &&
@@ -148,6 +151,18 @@ function isInList(attributes, element: typeof window.qwElement) {
     const roleSpecificATT = element.getElementAttribute(key);
     if (roleSpecificATT === value || (value === '' && roleSpecificATT !== null)) result = true;
   }
+  return result;
+}
+
+function verifyAriaLabel(ariaLabelBy: string, elementID: string | null) {
+  const elementIds = ariaLabelBy.split(' ');
+  let result = false;
+  for (const id of elementIds) {
+    if (!result && id !== '' && elementID !== id) {
+      result = window.qwPage.getElementByID(id) !== null;
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Img elements with empty alt but with valid aria-labelledby were ending up with role presentation incorrectly