### PR TITLE
fix: typo in `getImplicitRole.ts`

### DIFF
--- a/src/accessibilityUtils/getImplicitRole.ts
+++ b/src/accessibilityUtils/getImplicitRole.ts
@@ -45,7 +45,6 @@ function getImplicitRole(element: typeof window.qwElement, accessibleName: strin
                               role = roleValue['role'];
                           } 
                         }
-                      }
                     }
                 }
             }


### PR DESCRIPTION
I noticed a typo in the code while trying to compile the repo myself.

Tiny, tiny, extraneous semicolon :)